### PR TITLE
[BE][Feature] 캘린더 등록시 등록한 캘린더 엔티티 반환

### DIFF
--- a/src/main/java/com/mergeco/oiljang/myCalendar/repository/MyCalendarRepository.java
+++ b/src/main/java/com/mergeco/oiljang/myCalendar/repository/MyCalendarRepository.java
@@ -1,5 +1,6 @@
 package com.mergeco.oiljang.myCalendar.repository;
 
+import com.mergeco.oiljang.myCalendar.dto.MyCalendarDTO;
 import com.mergeco.oiljang.myCalendar.entity.MyCalendar;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,5 @@ import java.util.List;
 
 public interface MyCalendarRepository extends JpaRepository<MyCalendar, Integer> {
     List<MyCalendar> findByRefUserCode(int refUserCode);
+
 }

--- a/src/main/java/com/mergeco/oiljang/myCalendar/service/MyCalendarService.java
+++ b/src/main/java/com/mergeco/oiljang/myCalendar/service/MyCalendarService.java
@@ -30,13 +30,11 @@ public class MyCalendarService {
     }
 
     @Transactional
-    public String registMyCalendar(MyCalendarDTO myCalendarDTO) {
-        String result = "캘린더에 내용 등록 실패";
+    public MyCalendarDTO registMyCalendar(MyCalendarDTO myCalendarDTO) {
+        MyCalendar myCalendar = modelMapper.map(myCalendarDTO, MyCalendar.class);
+        myCalendarRepository.save(myCalendar);
 
-        myCalendarRepository.save(modelMapper.map(myCalendarDTO, MyCalendar.class));
-
-        result = "캘린더에 내용 등록 성공";
-        return result;
+        return modelMapper.map(myCalendar, MyCalendarDTO.class);
     }
 
     @Transactional

--- a/src/test/java/com/mergeco/oiljang/myCalendar/controller/MyCalendarControllerTests.java
+++ b/src/test/java/com/mergeco/oiljang/myCalendar/controller/MyCalendarControllerTests.java
@@ -55,7 +55,7 @@ public class MyCalendarControllerTests {
         //then
         Assertions.assertEquals(result.getStatusCodeValue(), 200);
         Assertions.assertEquals(result.getBody().getMessage(), "회원의 캘린더 내용 등록");
-        Assertions.assertTrue(result.getBody().getResults().get("result").equals("캘린더에 내용 등록 성공"));
+        Assertions.assertTrue(result.getBody().getResults().get("result") != null);
     }
 
     @Test


### PR DESCRIPTION
## 작업 분류
* * *
- #116 

## PR 타입
* * *
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [x] 기타 수정

## 개요
* * *
캘린더 등록시 등록한 캘린더 엔티티를 반환해서 events.js의 id와 인조 식별자를 인식시키도록 했습니다.

## 변경 사항
* * *
myCalendar 관련 service, controller 이에 따른 tests 변경

## 코드 리뷰시 참고 사항
* * *


## 테스트 결과
* * *
기존 테스트 성공, 컨트롤러 삽입 결과 체크를 list size 체크로 변경했습니다.

## 요청 사항
* * *

